### PR TITLE
Readme edits builtin functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,211 @@ user can insert cast explicitly.
 ```
 val s: * = (100 :> *) // 100 is casted to dynamic type ( `*` )
 ```
+
+## Built-in Functions
+
+Klassic supports some kind of built-in functions.
+
+### Standard output Functions
+
+- `println: (param:Any) => Any`  
+    display the `param` into the standard output.  
+    ```
+    println("Hello, World!")
+    ```
+
+- `printlnError: (param:Any) => Any`  
+    display the `param` into the standard error.  
+    ```
+    printlnError("Hello, World!")
+    ```
+
+### String Functions
+
+- `substring: (s:String, begin:Int, end:Int) => String`  
+    Returns a substring of the String `s`. The substring begins at the index `begin` and ends at the index `end` - 1.  
+    ```
+    substring("FOO", 0, 1) // => "F"
+    ```
+
+- `at: (s:String, index:Int) => String`  
+    Returns a String with a character value at the index `index` of the String `s`.  
+    ```
+    at("BAR", 2) // => "R"
+    ```
+
+- `matches: (s:String, regex:String) => Boolean`  
+    Returns true if the String `s` matches the regular expression `regex`, false otherwise.  
+    ```
+    val pattern = "[0-9]+"
+    matches("199", pattern) // => true
+    matches("a", pattern)   // => false
+    ```
+
+### Numeric Functions
+
+- `sqrt: (value:Double) => Double`  
+    Returns the square root of the Double `value`.
+    ```
+    sqrt(2.0) // => 1.4142135623730951
+    sqrt(9.0) // => 3.0
+    ```
+- `int: (vaue:Double) => Int`  
+    Returns the Double `value` as the Int value.
+    ```
+    int(3.14159265359) // => 3
+    ```
+
+- `double: (value:Int) => Double`  
+    Returns the Int `value` as the Double value.  
+    ```
+    double(10) // => 10.0
+    ```
+
+- `floor: (value:Double) => Int`  
+    Returns the truncated Double `value` as the Int value.
+    ```
+    floor(1.5) // => 1
+    floor(-1.5) // => -1
+    ```
+
+- `ceil: (value:Double) => Int`  
+    Returns the rounded-up Double `value` as the Int value.
+    ```
+    ceil(4.4)  // => 5
+    ceil(4.5)  // => 5
+    ceil(-4.4) // => -4
+    ceil(-4.5) // => -4
+    ```
+
+- `abs: (value:Double) => Double`  
+    Returns the absolute value of the Double `value`.
+    ```
+    abs(10.5)  // => 10.5
+    abs(-10.5) // => 10.5
+    ```
+
+### List Functions
+
+- `map: (list:List<'a>) => (fun:('a) => 'b) => List<'b>`  
+    Returns a new List consisting of the results of applying the given function `fun` to the elements of the given List `list`.
+    ```
+    map([1 2 3])((x) => x + 1) // => [2 3 4]
+    map([2 3 4]){x => x + 1}   // => [3 4 5]
+    ```
+
+- `head: (list:List<'a>) => List<'a>`  
+  Returns the first element of the List `list`.
+  ```
+  head([1 2 3 4]) // => 1
+  ```
+
+- `tail: (list:List<'a>) => List<'a>`  
+    Returns a new List consisting of the elements of the given List `list` except for the first element.
+    ```
+    tail([1 2 3 4]) // => [2 3 4]
+    ```
+
+- `cons: (value:'a) => (list:List<'a>) => List<'a>`  
+    Creates a new List, the head of which is `value` and the tail of which is `list`.  
+    ```
+    cons(1)([2 3 4]) // => [1 2 3 4]
+    ```
+
+- `size: (list:List<'a>) => Int`  
+    Returns the size of the List `list`.  
+    ```
+    size([1 2 3 4 5]) // => 5
+    ```
+
+- `isEmpty: (list:List<'a>) => Boolean`  
+    Returns true if the List `list` is empty, false otherwise.  
+    ```
+    isEmpty([])       // => true
+    isEmpty([1 2 3])  // => false
+    ```
+
+- `foldLeft: (list:List<'a>) => (acc:'b) => (fun:('b, 'a) => 'b) => 'b`  
+    Applies a function `fun` to a start value `acc` and all elements of the List `list`, going left to right.
+    ```
+    foldLeft([1 2 3 4])(0)((x, y) => x + y)         // => 10
+    foldLeft([1.0 2.0 3.0 4.0])(0.0){x, y => x + y} // => 10.0
+    foldLeft([1.0 2.0 3.0 4.0])(1.0){x, y => x * y} // => 24.0
+    ```
+
+### Thread Functions
+
+- `thread: (fun:() => Unit) => Unit`  
+    Creates a new thread and starts runnng the passed argument function `fun` asynchronously.  
+    ```
+    thread(() => {
+      sleep(1000)
+      println("Hello from another thread.")
+    })
+    println("Hello from main thread.")
+    // => "Hello from main thread."
+    // => "Hello from another thread."
+    ```
+
+- `sleep: (millis:Int) => Unit`  
+    Causes the current thread to sleep for the `millis` milliseconds.
+    ```
+    sleep(1000)
+    ```
+
+### Utility Functions
+
+- `stopwatch: (fun:() => Unit) => Int`  
+    Returns the time in milliseconds taken to evaluate the passed argument function `fun`.
+    ```
+    val time = stopwatch( => {
+      sleep(1000)
+      println("1")
+    })
+    println("it took #{time} milli seconds")
+    ```
+
+- `ToDo: () => Unit`  
+    Throws `klassic.runtime.NotImplementedError` when evaluated.
+    ```
+    ToDo()  // => throw NotImplementedError
+    ```
+
+### Assertion Functions
+
+- `assert: (condition:Boolean) => Unit`  
+    Asserts that the `condtion` should be true, and throws `klassic.runtime.AssertionError` if the `condition` is false.
+  ```
+  assert(2 == 1 + 1)  // => OK
+  assert(3 > 5)       // => NG: AssertionError
+  ```
+
+- `assertResult: (expected:Any)(actual:Any) => Unit`  
+    Asserts that the `actual` value should be equal to the `expected` value, and throws `klassic.runtime.AssertionError` if the `actual` value is not equal to the `expected` value.
+    ```
+    val add = (x, y) => {
+      x + y
+    }
+    assertResult(5)(add(2, 3))  // => OK
+    assertResult(2)(add(1, 2))  // => NG: AssertionError
+    ```
+
+### Interoperating Functions
+
+- `url: (value:String) => java.net.URL`  
+    Creates new `java.net.URL` object from a String `value`.
+    ```
+    url("https://github.com/klassic/klassic")
+    ```
+
+- `uri: (value:String) => java.net.URI`  
+    Creates new `java.net.URI` object from a String `value`.
+    ```
+    uri("https://github.com/klassic/klassic")
+    ```
+
+- `desktop: () => java.awt.Desktop`  
+    Returns the Desktop instance of the current browser context via Java Desktop API.
+    ```
+    desktop()->browse(uri("https://github.com/klassic/klassic"))
+    ```

--- a/test-programs/builtin_functions-interop.kl
+++ b/test-programs/builtin_functions-interop.kl
@@ -1,0 +1,17 @@
+// url
+val url1 = new java.net.URL("https://github.com/klassic/klassic")
+val url2 = url("https://github.com/klassic/klassic")
+println(url2)
+assertResult(url1)(url2)
+
+// uri
+val uri1 = new java.net.URI("https://github.com/klassic/klassic")
+val uri2 = uri("https://github.com/klassic/klassic")
+println(uri2)
+assertResult(uri1)(uri2)
+
+// desktop()
+val dt = desktop();
+println(dt)
+println(dt->isDesktopSupported())
+// dt->mail()

--- a/test-programs/builtin_functions-interop.kl
+++ b/test-programs/builtin_functions-interop.kl
@@ -10,8 +10,8 @@ val uri2 = uri("https://github.com/klassic/klassic")
 println(uri2)
 assertResult(uri1)(uri2)
 
-// desktop()
-val dt = desktop();
-println(dt)
-println(dt->isDesktopSupported())
+// desktop() -- not supported in Travis CI environment
+//val dt = desktop();
+//println(dt)
+//println(dt->isDesktopSupported())
 // dt->mail()

--- a/test-programs/builtin_functions-list.kl
+++ b/test-programs/builtin_functions-list.kl
@@ -1,0 +1,24 @@
+// map
+assertResult([2 3 4])(map([1 2 3])((x) => x + 1))
+assertResult([3 4 5])(map([2 3 4]){x => x + 1})
+
+// head
+assertResult(1)(head([1 2 3 4]))
+
+// tail
+assertResult([2 3 4])(tail([1 2 3 4]))
+
+// cons
+assertResult([1 2 3 4])(cons(1)([2 3 4]))
+
+// size
+assertResult(5)(size([1 2 3 4 5]))
+
+// isEmpty
+assertResult(true)(isEmpty([]))
+assertResult(false)(isEmpty([1 2 3]))
+
+// foldLeft
+assertResult(10)(foldLeft([1 2 3 4])(0)((x, y) => x + y))
+assertResult(10.0)(foldLeft([1.0 2.0 3.0 4.0])(0.0){x, y => x + y})
+assertResult(24.0)(foldLeft([1.0 2.0 3.0 4.0])(1.0){x, y => x * y})

--- a/test-programs/builtin_functions-thread.kl
+++ b/test-programs/builtin_functions-thread.kl
@@ -1,0 +1,5 @@
+thread(() => {
+    sleep(1000)
+    println("Hello from another thread.")
+})
+println("Hello from main thread.")

--- a/test-programs/builtin_functions.kl
+++ b/test-programs/builtin_functions.kl
@@ -1,10 +1,31 @@
+// String Functions
 val pattern = "[0-9]+"
 assertResult("F")(substring("FOO", 0, 1))
+assertResult("R")(at("BAR", 2))
 assertResult(true)(matches("199", pattern))
 assertResult(true)(matches("200", pattern))
 assertResult(false)(matches("a", pattern))
 val sub = substring
 assertResult("B")(sub("BAR", 0, 1))
+
+// Numeric Functions
+assertResult(1.4142135623730951)(sqrt(2.0))
+assertResult(3.0)(sqrt(9.0))
+assertResult(3)(int(3.14159265359))
+assertResult(10.0)(double(10))
+assertResult(1)(floor(1.5))
+assertResult(-1)(floor(-1.5))
+assertResult(5)(ceil(4.4))
+assertResult(5)(ceil(4.5))
+assertResult(-4)(ceil(-4.4))
+assertResult(-4)(ceil(-4.5))
+assertResult(10.5)(abs(10.5))
+assertResult(10.5)(abs(-10.5))
+
+// Assert Function
+assert(2 == 1 + 1)
+// assert(3 > 5) // => throws AssertionError
+
 val add = (x, y) => {
   x + y
 }


### PR DESCRIPTION
お疲れ様です。

ソースを見ながら README.md に Built-in Functions の説明を足してみました。
一応、JavaのAPI Doc, ScalaのAPI Doc, Common LispのAPI Doc辺りを参考にそれっぽい英語になるようにしつつ、丸写しにはならないようにアレンジしてみました。  

あと、RADME.md の説明に書いたサンプルコードは、対応するコードを test-programs の中に入れるようにしています。 
 
サンプルコードとして一つ心残りなのは、`desktop()->browser(uri("..."))` のコードが klassic 0.1.0-alpha では動作しなくなっているようなのですが、他に適切なサンプルが見つからないので、そのまま載せています。

各関数のシグネチャは、既存のREADME.mdの記述や水島さんのプレゼン資料を見ながら、見よう見まねで書いてみましたが、ジェネリクスやmap/foldLeftなどのリスト関数の書き方はあまり自信がないので間違っていたらすみません。

よろしければたたき台として使ってください。
